### PR TITLE
Policy equality

### DIFF
--- a/src/burlap/assignment4/EasyGridWorldLauncher.java
+++ b/src/burlap/assignment4/EasyGridWorldLauncher.java
@@ -34,6 +34,10 @@ public class EasyGridWorldLauncher {
 	private static Integer MAX_ITERATIONS = 100;
 	private static Integer NUM_INTERVALS = 100;
 
+	//can be set to stop running VI and PI when the policy found
+	//is the same five times in a row
+	private static boolean runUntilConverge = false;
+
 	protected static int[][] userMap = new int[][] { 
 			{ 0, 0, 0, 0, 0},
 			{ 0, 1, 1, 1, 0},
@@ -71,7 +75,7 @@ public class EasyGridWorldLauncher {
 			visualizeInitialGridWorld(domain, gen, env);
 		}
 		
-		AnalysisRunner runner = new AnalysisRunner(MAX_ITERATIONS,NUM_INTERVALS);
+		AnalysisRunner runner = new AnalysisRunner(MAX_ITERATIONS,NUM_INTERVALS, runUntilConverge);
 		if(runValueIteration){
 			runner.runValueIteration(gen,domain,initialState, rf, tf, showValueIterationPolicyMap);
 		}
@@ -107,13 +111,13 @@ public class EasyGridWorldLauncher {
 				if(arg.contains("=")){
 					String[] split = arg.trim().split("=");
 					if(split.length > 1){
-						if(split[0].equals("rvi")){
+						if(split[0].equals("vi")){
 							runValueIteration = Boolean.parseBoolean(split[1]);
 						}
-						if(split[0].equals("rpi")){
+						if(split[0].equals("pi")){
 							runPolicyIteration = Boolean.parseBoolean(split[1]);
 						}
-						if(split[0].equals("rql")){
+						if(split[0].equals("ql")){
 							runQLearning = Boolean.parseBoolean(split[1]);
 						}
 						if(split[0].equals("iterations")){
@@ -129,6 +133,9 @@ public class EasyGridWorldLauncher {
 							} catch (NumberFormatException nfe){
 								System.out.println("Unable to parse intervals "+split[1]+" into integer. Defaulting to "+NUM_INTERVALS);
 							}
+						}
+						if(split[0].equals("converge")){
+							runUntilConverge = Boolean.parseBoolean(split[1]);
 						}
 					} else {
 						System.out.println("invalid argument "+arg+". Use name=value format");

--- a/src/burlap/assignment4/EasyGridWorldLauncher.java
+++ b/src/burlap/assignment4/EasyGridWorldLauncher.java
@@ -35,8 +35,8 @@ public class EasyGridWorldLauncher {
 	private static Integer NUM_INTERVALS = 100;
 
 	//can be set to stop running VI and PI when the policy found
-	//is the same five times in a row
 	private static boolean runUntilConverge = false;
+	private static int convergeCount = 5;
 
 	protected static int[][] userMap = new int[][] { 
 			{ 0, 0, 0, 0, 0},
@@ -75,7 +75,7 @@ public class EasyGridWorldLauncher {
 			visualizeInitialGridWorld(domain, gen, env);
 		}
 		
-		AnalysisRunner runner = new AnalysisRunner(MAX_ITERATIONS,NUM_INTERVALS, runUntilConverge);
+		AnalysisRunner runner = new AnalysisRunner(MAX_ITERATIONS,NUM_INTERVALS, runUntilConverge, convergeCount);
 		if(runValueIteration){
 			runner.runValueIteration(gen,domain,initialState, rf, tf, showValueIterationPolicyMap);
 		}
@@ -136,6 +136,13 @@ public class EasyGridWorldLauncher {
 						}
 						if(split[0].equals("converge")){
 							runUntilConverge = Boolean.parseBoolean(split[1]);
+						}
+						if(split[0].equals("cc")){
+							try{
+								convergeCount = Integer.parseInt(split[1]);
+							} catch (NumberFormatException nfe){
+								System.out.println("Unable to parse converge count "+split[1]+" into integer. Defaulting to "+convergeCount);
+							}
 						}
 					} else {
 						System.out.println("invalid argument "+arg+". Use name=value format");

--- a/src/burlap/assignment4/EasyGridWorldLauncher.java
+++ b/src/burlap/assignment4/EasyGridWorldLauncher.java
@@ -13,6 +13,8 @@ import burlap.oomdp.singleagent.environment.SimulatedEnvironment;
 import burlap.oomdp.singleagent.explorer.VisualExplorer;
 import burlap.oomdp.visualizer.Visualizer;
 
+import java.lang.NumberFormatException;
+
 public class EasyGridWorldLauncher {
 	//These are some boolean variables that affect what will actually get executed
 	private static boolean visualizeInitialGridWorld = true; //Loads a GUI with the agent, walls, and goal
@@ -42,6 +44,9 @@ public class EasyGridWorldLauncher {
 //	private static Integer mapLen = map.length-1;
 
 	public static void main(String[] args) {
+
+		parseArgs(args);
+
 		// convert to BURLAP indexing
 		int[][] map = MapPrinter.mapToMatrix(userMap);
 		int maxX = map.length-1;
@@ -93,6 +98,46 @@ public class EasyGridWorldLauncher {
 
 		exp.initGUI();
 
+	}
+
+	private static void parseArgs(String[] args){
+		if(args != null && args.length > 0){
+			for(int i = 0; i<args.length; i++){
+				String arg = args[i];
+				if(arg.contains("=")){
+					String[] split = arg.trim().split("=");
+					if(split.length > 1){
+						if(split[0].equals("rvi")){
+							runValueIteration = Boolean.parseBoolean(split[1]);
+						}
+						if(split[0].equals("rpi")){
+							runPolicyIteration = Boolean.parseBoolean(split[1]);
+						}
+						if(split[0].equals("rql")){
+							runQLearning = Boolean.parseBoolean(split[1]);
+						}
+						if(split[0].equals("iterations")){
+							try{
+								MAX_ITERATIONS = Integer.parseInt(split[1]);
+							} catch (NumberFormatException nfe){
+								System.out.println("Unable to parse iterations "+split[1]+" into integer. Defaulting to "+MAX_ITERATIONS);
+							}
+						}
+						if(split[0].equals("intervals")){
+							try{
+								NUM_INTERVALS = Integer.parseInt(split[1]);
+							} catch (NumberFormatException nfe){
+								System.out.println("Unable to parse intervals "+split[1]+" into integer. Defaulting to "+NUM_INTERVALS);
+							}
+						}
+					} else {
+						System.out.println("invalid argument "+arg+". Use name=value format");
+					}
+				} else {
+					System.out.println("invalid argument "+arg+". Use name=value format");
+				}
+			}
+		}
 	}
 	
 

--- a/src/burlap/assignment4/HardGridWorldLauncher.java
+++ b/src/burlap/assignment4/HardGridWorldLauncher.java
@@ -30,6 +30,10 @@ public class HardGridWorldLauncher {
 	private static boolean showValueIterationPolicyMap = true; 
 	private static boolean showPolicyIterationPolicyMap = false;
 	private static boolean showQLearningPolicyMap = false;
+
+	//can be set to stop running VI and PI when the policy found
+	//is the same five times in a row
+	private static boolean runUntilConverge = false;
 	
 	private static Integer MAX_ITERATIONS = 100;
 	private static Integer NUM_INTERVALS = 100;
@@ -77,7 +81,7 @@ public class HardGridWorldLauncher {
 			visualizeInitialGridWorld(domain, gen, env);
 		}
 		
-		AnalysisRunner runner = new AnalysisRunner(MAX_ITERATIONS,NUM_INTERVALS);
+		AnalysisRunner runner = new AnalysisRunner(MAX_ITERATIONS,NUM_INTERVALS, runUntilConverge);
 		if(runValueIteration){
 			runner.runValueIteration(gen,domain,initialState, rf, tf, showValueIterationPolicyMap);
 		}
@@ -135,6 +139,9 @@ public class HardGridWorldLauncher {
 							} catch (NumberFormatException nfe){
 								System.out.println("Unable to parse intervals "+split[1]+" into integer. Defaulting to "+NUM_INTERVALS);
 							}
+						}
+						if(split[0].equals("converge")){
+							runUntilConverge = Boolean.parseBoolean(split[1]);
 						}
 					} else {
 						System.out.println("invalid argument "+arg+". Use name=value format");

--- a/src/burlap/assignment4/HardGridWorldLauncher.java
+++ b/src/burlap/assignment4/HardGridWorldLauncher.java
@@ -13,6 +13,8 @@ import burlap.oomdp.singleagent.environment.SimulatedEnvironment;
 import burlap.oomdp.singleagent.explorer.VisualExplorer;
 import burlap.oomdp.visualizer.Visualizer;
 
+import java.lang.NumberFormatException;
+
 public class HardGridWorldLauncher {
 	//These are some boolean variables that affect what will actually get executed
 	private static boolean visualizeInitialGridWorld = true; //Loads a GUI with the agent, walls, and goal
@@ -48,6 +50,9 @@ public class HardGridWorldLauncher {
 //	private static Integer mapLen = map.length-1;
 
 	public static void main(String[] args) {
+
+		parseArgs(args);
+
 		// convert to BURLAP indexing
 		int[][] map = MapPrinter.mapToMatrix(userMap);
 		int maxX = map.length-1;

--- a/src/burlap/assignment4/HardGridWorldLauncher.java
+++ b/src/burlap/assignment4/HardGridWorldLauncher.java
@@ -32,8 +32,8 @@ public class HardGridWorldLauncher {
 	private static boolean showQLearningPolicyMap = false;
 
 	//can be set to stop running VI and PI when the policy found
-	//is the same five times in a row
 	private static boolean runUntilConverge = false;
+	private static int convergeCount = 5;
 	
 	private static Integer MAX_ITERATIONS = 100;
 	private static Integer NUM_INTERVALS = 100;
@@ -81,7 +81,7 @@ public class HardGridWorldLauncher {
 			visualizeInitialGridWorld(domain, gen, env);
 		}
 		
-		AnalysisRunner runner = new AnalysisRunner(MAX_ITERATIONS,NUM_INTERVALS, runUntilConverge);
+		AnalysisRunner runner = new AnalysisRunner(MAX_ITERATIONS,NUM_INTERVALS, runUntilConverge, convergeCount);
 		if(runValueIteration){
 			runner.runValueIteration(gen,domain,initialState, rf, tf, showValueIterationPolicyMap);
 		}

--- a/src/burlap/assignment4/HardGridWorldLauncher.java
+++ b/src/burlap/assignment4/HardGridWorldLauncher.java
@@ -100,6 +100,46 @@ public class HardGridWorldLauncher {
 		exp.initGUI();
 
 	}
+
+	private static void parseArgs(String[] args){
+		if(args != null && args.length > 0){
+			for(int i = 0; i<args.length; i++){
+				String arg = args[i];
+				if(arg.contains("=")){
+					String[] split = arg.trim().split("=");
+					if(split.length > 1){
+						if(split[0].equals("rvi")){
+							runValueIteration = Boolean.parseBoolean(split[1]);
+						}
+						if(split[0].equals("rpi")){
+							runPolicyIteration = Boolean.parseBoolean(split[1]);
+						}
+						if(split[0].equals("rql")){
+							runQLearning = Boolean.parseBoolean(split[1]);
+						}
+						if(split[0].equals("iterations")){
+							try{
+								MAX_ITERATIONS = Integer.parseInt(split[1]);
+							} catch (NumberFormatException nfe){
+								System.out.println("Unable to parse iterations "+split[1]+" into integer. Defaulting to "+MAX_ITERATIONS);
+							}
+						}
+						if(split[0].equals("intervals")){
+							try{
+								NUM_INTERVALS = Integer.parseInt(split[1]);
+							} catch (NumberFormatException nfe){
+								System.out.println("Unable to parse intervals "+split[1]+" into integer. Defaulting to "+NUM_INTERVALS);
+							}
+						}
+					} else {
+						System.out.println("invalid argument "+arg+". Use name=value format");
+					}
+				} else {
+					System.out.println("invalid argument "+arg+". Use name=value format");
+				}
+			}
+		}
+	}
 	
 
 }

--- a/src/burlap/assignment4/util/AnalysisRunner.java
+++ b/src/burlap/assignment4/util/AnalysisRunner.java
@@ -28,11 +28,13 @@ public class AnalysisRunner {
 	private int MAX_ITERATIONS;
 	private int NUM_INTERVALS;
 	private boolean runUntilConvergence;
+	private int convergeCount;
 
-	public AnalysisRunner(int MAX_ITERATIONS, int NUM_INTERVALS, boolean converge){
+	public AnalysisRunner(int MAX_ITERATIONS, int NUM_INTERVALS){
 		this.MAX_ITERATIONS = MAX_ITERATIONS;
 		this.NUM_INTERVALS = NUM_INTERVALS;
-		this.runUntilConvergence = converge;
+		this.runUntilConvergence = false;
+		this.convergeCount = 5;
 
 		int increment = MAX_ITERATIONS/NUM_INTERVALS;
 		for(int numIterations = increment;numIterations<=MAX_ITERATIONS;numIterations+=increment ){
@@ -41,6 +43,21 @@ public class AnalysisRunner {
 		}
 
 	}
+
+	public AnalysisRunner(int MAX_ITERATIONS, int NUM_INTERVALS, boolean converge, int convergeCount){
+		this.MAX_ITERATIONS = MAX_ITERATIONS;
+		this.NUM_INTERVALS = NUM_INTERVALS;
+		this.runUntilConvergence = converge;
+		this.convergeCount = convergeCount;
+
+		int increment = MAX_ITERATIONS/NUM_INTERVALS;
+		for(int numIterations = increment;numIterations<=MAX_ITERATIONS;numIterations+=increment ){
+			AnalysisAggregator.addNumberOfIterations(numIterations);
+
+		}
+
+	}
+
 	public void runValueIteration(BasicGridWorld gen, Domain domain,
 			State initialState, RewardFunction rf, TerminalFunction tf, boolean showPolicyMap) {
 		System.out.println("//Value Iteration Analysis//");
@@ -74,8 +91,8 @@ public class AnalysisRunner {
 				if(lastPolicy.checkPolicyEqualityForDP(p, vi, tf)){
 					//System.out.println("Policies are the same for all states");
 					samePolicy++;
-					if(runUntilConvergence && samePolicy == 5){
-						System.out.println("Same policy for last five iterations starting at "+(numIterations-5));
+					if(runUntilConvergence && samePolicy == convergeCount){
+						System.out.println("Same policy for last five iterations starting at "+(numIterations-convergeCount));
 						break;
 					}
 				}
@@ -100,7 +117,7 @@ public class AnalysisRunner {
 		Policy lastPolicy = null;
 		Policy p = null;
 		int samePolicy = 0;
-		
+
 		EpisodeAnalysis ea = null;
 		int increment = MAX_ITERATIONS/NUM_INTERVALS;
 		for(int numIterations = increment;numIterations<=MAX_ITERATIONS;numIterations+=increment ){
@@ -125,8 +142,8 @@ public class AnalysisRunner {
 				if(lastPolicy.checkPolicyEqualityForDP(p, pi, tf)){
 					//System.out.println("Policies are the same for all states");
 					samePolicy++;
-					if(runUntilConvergence && samePolicy == 5){
-						System.out.println("Same policy for last five iterations starting at "+(numIterations-5));
+					if(runUntilConvergence && samePolicy == convergeCount){
+						System.out.println("Same policy for last "+convergeCount+" iterations starting at "+(numIterations-convergeCount));
 						break;
 					}
 				}

--- a/src/burlap/assignment4/util/AnalysisRunner.java
+++ b/src/burlap/assignment4/util/AnalysisRunner.java
@@ -27,11 +27,13 @@ public class AnalysisRunner {
 
 	private int MAX_ITERATIONS;
 	private int NUM_INTERVALS;
+	private boolean runUntilConvergence;
 
-	public AnalysisRunner(int MAX_ITERATIONS, int NUM_INTERVALS){
+	public AnalysisRunner(int MAX_ITERATIONS, int NUM_INTERVALS, boolean converge){
 		this.MAX_ITERATIONS = MAX_ITERATIONS;
 		this.NUM_INTERVALS = NUM_INTERVALS;
-		
+		this.runUntilConvergence = converge;
+
 		int increment = MAX_ITERATIONS/NUM_INTERVALS;
 		for(int numIterations = increment;numIterations<=MAX_ITERATIONS;numIterations+=increment ){
 			AnalysisAggregator.addNumberOfIterations(numIterations);
@@ -43,7 +45,10 @@ public class AnalysisRunner {
 			State initialState, RewardFunction rf, TerminalFunction tf, boolean showPolicyMap) {
 		System.out.println("//Value Iteration Analysis//");
 		ValueIteration vi = null;
+		Policy lastPolicy = null;
 		Policy p = null;
+		int samePolicy = 0;
+
 		EpisodeAnalysis ea = null;
 		int increment = MAX_ITERATIONS/NUM_INTERVALS;
 		for(int numIterations = increment;numIterations<=MAX_ITERATIONS;numIterations+=increment ){
@@ -64,6 +69,18 @@ public class AnalysisRunner {
 			// evaluate the policy with one roll out visualize the trajectory
 			ea = p.evaluateBehavior(initialState, rf, tf);
 			AnalysisAggregator.addStepsToFinishValueIteration(ea.numTimeSteps());
+
+			if(!(lastPolicy == null)){
+				if(lastPolicy.checkPolicyEqualityForDP(p, vi, tf)){
+					//System.out.println("Policies are the same for all states");
+					samePolicy++;
+					if(runUntilConvergence && samePolicy == 5){
+						System.out.println("Same policy for last five iterations starting at "+(numIterations-5));
+						break;
+					}
+				}
+			} 
+			lastPolicy = p;
 		}
 		
 //		Visualizer v = gen.getVisualizer();
@@ -80,7 +97,10 @@ public class AnalysisRunner {
 			State initialState, RewardFunction rf, TerminalFunction tf, boolean showPolicyMap) {
 		System.out.println("//Policy Iteration Analysis//");
 		PolicyIteration pi = null;
+		Policy lastPolicy = null;
 		Policy p = null;
+		int samePolicy = 0;
+		
 		EpisodeAnalysis ea = null;
 		int increment = MAX_ITERATIONS/NUM_INTERVALS;
 		for(int numIterations = increment;numIterations<=MAX_ITERATIONS;numIterations+=increment ){
@@ -100,6 +120,18 @@ public class AnalysisRunner {
 			// evaluate the policy with one roll out visualize the trajectory
 			ea = p.evaluateBehavior(initialState, rf, tf);
 			AnalysisAggregator.addStepsToFinishPolicyIteration(ea.numTimeSteps());
+
+			if(!(lastPolicy == null)){
+				if(lastPolicy.checkPolicyEqualityForDP(p, pi, tf)){
+					//System.out.println("Policies are the same for all states");
+					samePolicy++;
+					if(runUntilConvergence && samePolicy == 5){
+						System.out.println("Same policy for last five iterations starting at "+(numIterations-5));
+						break;
+					}
+				}
+			} 
+			lastPolicy = p;
 		}
 
 //		Visualizer v = gen.getVisualizer();

--- a/src/burlap/behavior/policy/GreedyQPolicy.java
+++ b/src/burlap/behavior/policy/GreedyQPolicy.java
@@ -69,6 +69,7 @@ public class GreedyQPolicy extends Policy implements SolverDerivedPolicy {
 				maxQ = q.q;
 			}
 		}
+		//System.out.println("maxActions size "+maxActions.size());
 		int selected = rand.nextInt(maxActions.size());
 		//return translated action parameters if the action is parameterized with objects in a object identifier independent domain
 		AbstractGroundedAction srcA = maxActions.get(selected).a;

--- a/src/burlap/behavior/policy/Policy.java
+++ b/src/burlap/behavior/policy/Policy.java
@@ -3,6 +3,9 @@ package burlap.behavior.policy;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.Iterator;
+
+import burlap.behavior.singleagent.planning.stochastic.DynamicProgramming;
 
 import burlap.behavior.singleagent.EpisodeAnalysis;
 import burlap.behavior.singleagent.options.Option;
@@ -386,6 +389,33 @@ public abstract class Policy {
 		}while(!env.isInTerminalState() && nSteps < numSteps);
 
 		return ea;
+	}
+
+	public boolean checkPolicyEqualityForDP(Policy p, DynamicProgramming dp, TerminalFunction tf){
+		List<State> states = dp.getAllStates();
+		boolean equal = true;
+		Iterator<State> it = states.iterator();
+		while(it.hasNext()){
+			State s = it.next();
+
+			//check if both policies have an action regarding this state
+			if(this.isDefinedFor(s) && p.isDefinedFor(s)){
+
+				//make sure this state is not terminal 
+				if(!tf.isTerminal(s)){
+					//check that the names of the actions equal (for now)
+					if(!(this.getAction(s).actionName().equals(p.getAction(s).actionName()))) {
+						equal = false;
+						break;
+					}
+				}
+			} else {
+				System.out.println("policy not defined for state");
+				equal = false;
+				break;
+			}
+		}
+		return equal;
 	}
 
 


### PR DESCRIPTION
Added methods for parsing command line arguments so that testing can be done without recompilation
Valid command options are 
vi=true (run value iteration)
pi=true (run policy iteration)
ql=true (run QLearning)
converge=true (run until consecutive policies are equal to one another)
cc=5 (integer representing the number of policies need to be equal to consider convergence)

Created a method for checking if two policies are equal to one another to test convergence. Policies are equal to one another if for all valid states the same action is selected.

Notes:
For value iteration convergence seems to be working properly. For policy iteration the policies converge quickly but are not optimal. Haven't wrapped my head around this yet.
